### PR TITLE
[#6] 로깅 AOP에서 작업 수행 메서드의 파라미터명을 받아 오지 못하는 문제 해결

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
+        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <junit.version>5.9.2</junit.version>
     </properties>
 
@@ -143,6 +144,19 @@
                     <username>admin</username>
                     <password>admin</password>
                     <path>/</path>
+                </configuration>
+            </plugin>
+
+            <!-- Reflection for Logging Aspect -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgument>-parameters</compilerArgument>
+                    <testCompilerArgument>-parameters</testCompilerArgument>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## resolve #6

## 변경사항
- 설정 파일에 리플렉션 관련 설정 추가
    - pom.xml에 maven compiler plugin 추가

## 참고
- https://stackoverflow.com/questions/2237803/can-i-obtain-method-parameter-name-using-java-reflection
