### PR TITLE
[#15] 강좌 목록 조회 기능 추가

### DIFF
--- a/src/main/java/org/chulgang/hrd/course/controller/GetCoursesController.java
+++ b/src/main/java/org/chulgang/hrd/course/controller/GetCoursesController.java
@@ -1,0 +1,66 @@
+package org.chulgang.hrd.course.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.chulgang.hrd.aop.LoggingAspect;
+import org.chulgang.hrd.course.model.service.CourseService;
+import org.chulgang.hrd.util.FormatConverter;
+import org.chulgang.hrd.util.FormatValidator;
+
+import java.io.IOException;
+
+import static org.chulgang.hrd.course.util.RequestConstant.*;
+
+@WebServlet(urlPatterns = {GET_COURSES_FIRST_REQUEST_URL, GET_COURSES_SECOND_REQUEST_URL})
+public class GetCoursesController extends HttpServlet {
+    private CourseService courseService;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+
+        courseService = LoggingAspect.createProxy(CourseService.class,
+                (CourseService) config.getServletContext().getAttribute(COURSE_SERVICE_ATTRIBUTE_NAME));
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        if (request.getRequestURI().contains(String.format("%s/", COURSE_DOMAIN_NAME))) {
+            response.sendRedirect(GET_COURSES_SECOND_REQUEST_URL);
+            return;
+        }
+
+        if (FormatValidator.isNoValue(request.getParameter(SEARCH_WORD_PARAMETER_NAME))) {
+            getAllCourses(request, response);
+        }
+
+        // TODO: 검색 기능 추가
+    }
+
+    private void getAllCourses(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // TODO: 이미지 추가
+
+        String size = request.getParameter(SIZE_PARAMETER_NAME);
+        int parsedSize = 0;
+        if (!FormatValidator.isNoValue(size)) {
+            parsedSize = FormatConverter.parseToInt(size);
+        }
+
+        String pageNumber = request.getParameter(PAGE_NUMBER_PARAMETER_NAME);
+        int parsedPageNumber = 0;
+        if (!FormatValidator.isNoValue(pageNumber)) {
+            parsedPageNumber = FormatConverter.parseToInt(pageNumber);
+        }
+
+        request.setAttribute(COURSES_ATTRIBUTE_NAME, courseService.getCourses(parsedSize, parsedPageNumber));
+
+        RequestDispatcher requestDispatcher = request.getRequestDispatcher(COURSES_VIEW);
+        requestDispatcher.forward(request, response);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/domain/Course.java
+++ b/src/main/java/org/chulgang/hrd/course/domain/Course.java
@@ -1,0 +1,220 @@
+package org.chulgang.hrd.course.domain;
+
+
+import org.chulgang.hrd.util.FormatConverter;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class Course {
+    private Long id;
+    private Long subjectId;
+    private Long teacherId;
+    private Long timePeriodId;
+    private String name;
+    private String description;
+    private int price;
+    private LocalDate startDate;
+    private LocalDate lastDate;
+    private float averageScore;
+    private int remainedSeat;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public Course() {
+    }
+
+    private Course(
+            Long subjectId, Long teacherId, Long timePeriodId, String name,
+            String description, int price, LocalDate startDate, LocalDate lastDate
+    ) {
+        this.subjectId = subjectId;
+        this.teacherId = teacherId;
+        this.timePeriodId = timePeriodId;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.startDate = startDate;
+        this.lastDate = lastDate;
+    }
+
+    private Course(
+            Long id, String name, String description, int price, LocalDate startDate, LocalDate lastDate,
+            float averageScore, int remainedSeat, LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.startDate = startDate;
+        this.lastDate = lastDate;
+        this.averageScore = averageScore;
+        this.remainedSeat = remainedSeat;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    private Course(
+            Long id, Long subjectId, Long teacherId, Long timePeriodId, String name,
+            String description, int price, LocalDate startDate, LocalDate lastDate
+    ) {
+        this.id = id;
+        this.subjectId = subjectId;
+        this.teacherId = teacherId;
+        this.timePeriodId = timePeriodId;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.startDate = startDate;
+        this.lastDate = lastDate;
+    }
+
+    private Course(
+            Long id, Long subjectId, Long teacherId, Long timePeriodId, String name, String description,
+            int price, LocalDate startDate, LocalDate lastDate, float averageScore, int remainedSeat,
+            LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.id = id;
+        this.subjectId = subjectId;
+        this.teacherId = teacherId;
+        this.timePeriodId = timePeriodId;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.startDate = startDate;
+        this.lastDate = lastDate;
+        this.averageScore = averageScore;
+        this.remainedSeat = remainedSeat;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static Course from(String[] data) {
+        LocalDateTime modifiedAt = data[12] == null ? null : FormatConverter.parseToDateTime(data[12]);
+
+        return new Course(
+                Long.parseLong(data[0]),
+                Long.parseLong(data[1]),
+                Long.parseLong(data[2]),
+                Long.parseLong(data[3]),
+                data[4],
+                data[5],
+                FormatConverter.parseToInt(data[6]),
+                FormatConverter.parseToDate(data[7]),
+                FormatConverter.parseToDate(data[8]),
+                FormatConverter.parseToFloat(data[9]),
+                FormatConverter.parseToInt(data[10]),
+                FormatConverter.parseToDateTime(data[11]),
+                modifiedAt
+        );
+    }
+
+    protected static Course of(
+            Long id, Long subjectId, Long teacherId, Long timePeriodId, String name,
+            String description, int price, LocalDate startDate, LocalDate lastDate
+    ) {
+        return new Course(id, subjectId, teacherId, timePeriodId, name, description, price, startDate, lastDate);
+    }
+
+    protected static Course of(
+            Long id, String name, String description, int price, LocalDate startDate, LocalDate lastDate,
+            float averageScore, int remainedSeat, LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        return new Course(id, name, description, price, startDate, lastDate, averageScore, remainedSeat, createdAt, modifiedAt);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        Course course = (Course) object;
+        return price == course.price
+                && Float.compare(averageScore, course.averageScore) == 0
+                && remainedSeat == course.remainedSeat
+                && Objects.equals(id, course.id)
+                && Objects.equals(subjectId, course.subjectId)
+                && Objects.equals(teacherId, course.teacherId)
+                && Objects.equals(timePeriodId, course.timePeriodId)
+                && Objects.equals(name, course.name)
+                && Objects.equals(description, course.description)
+                && Objects.equals(startDate, course.startDate)
+                && Objects.equals(lastDate, course.lastDate)
+                && Objects.equals(modifiedAt, course.modifiedAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                id, subjectId, teacherId, timePeriodId, name, description, price,
+                startDate, lastDate, averageScore, remainedSeat, modifiedAt
+        );
+    }
+
+    public void setTupleValues(PreparedStatement preparedStatement) throws SQLException {
+        preparedStatement.setLong(1, id);
+        preparedStatement.setLong(2, subjectId);
+        preparedStatement.setLong(3, teacherId);
+        preparedStatement.setLong(4, timePeriodId);
+        preparedStatement.setString(5, name);
+        preparedStatement.setString(6, description);
+        preparedStatement.setInt(7, price);
+        preparedStatement.setObject(8, startDate);
+        preparedStatement.setObject(9, lastDate);
+        preparedStatement.setInt(10, remainedSeat);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getSubjectId() {
+        return subjectId;
+    }
+
+    public Long getTeacherId() {
+        return teacherId;
+    }
+
+    public Long getTimePeriodId() {
+        return timePeriodId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getLastDate() {
+        return lastDate;
+    }
+
+    public float getAverageScore() {
+        return averageScore;
+    }
+
+    public int getRemainedSeat() {
+        return remainedSeat;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getModifiedAt() {
+        return modifiedAt;
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/dto/GetCoursesResponse.java
+++ b/src/main/java/org/chulgang/hrd/course/dto/GetCoursesResponse.java
@@ -1,0 +1,32 @@
+package org.chulgang.hrd.course.dto;
+
+import org.chulgang.hrd.course.domain.Course;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetCoursesResponse {
+    private List<GetCourseResponse> getCourseResponses;
+
+    private GetCoursesResponse(List<GetCourseResponse> getCourseResponses) {
+        this.getCourseResponses = getCourseResponses;
+    }
+
+    public List<GetCourseResponse> getCourseResponses() {
+        return getCourseResponses;
+    }
+
+    public GetCourseResponse get(int idx) {
+        return getCourseResponses.get(idx);
+    }
+
+    public static GetCoursesResponse from(List<Course> courses) {
+        List<GetCourseResponse> getCourseResponses = new ArrayList<GetCourseResponse>();
+
+        for (Course course : courses) {
+            getCourseResponses.add(GetCourseResponse.from(course));
+        }
+
+        return new GetCoursesResponse(getCourseResponses);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/exception/CourseIdNotFoundException.java
+++ b/src/main/java/org/chulgang/hrd/course/exception/CourseIdNotFoundException.java
@@ -1,0 +1,9 @@
+package org.chulgang.hrd.course.exception;
+
+import org.chulgang.hrd.exception.EntityNotFoundException;
+
+public class CourseIdNotFoundException extends EntityNotFoundException {
+    public CourseIdNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/exception/ExceptionMessage.java
+++ b/src/main/java/org/chulgang/hrd/course/exception/ExceptionMessage.java
@@ -1,0 +1,6 @@
+package org.chulgang.hrd.course.exception;
+
+public class ExceptionMessage {
+    public static final String COURSE_ID_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 강좌를 찾을 수 없습니다. 다시 시도해 주세요. 전송된 ID: %d";
+}

--- a/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepository.java
+++ b/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepository.java
@@ -1,0 +1,9 @@
+package org.chulgang.hrd.course.model.repository;
+
+import org.chulgang.hrd.course.domain.Course;
+
+import java.util.List;
+
+public interface CourseRepository {
+    List<Course> findAll(int size, int pageNumber);
+}

--- a/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepositoryImpl.java
+++ b/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepositoryImpl.java
@@ -1,0 +1,48 @@
+package org.chulgang.hrd.course.model.repository;
+
+import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.util.ConnectionContainer;
+import org.chulgang.hrd.util.DataSelector;
+import org.chulgang.hrd.util.StatementGenerator;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CourseRepositoryImpl implements CourseRepository {
+    private static final CourseRepositoryImpl INSTANCE = new CourseRepositoryImpl();
+
+    public static CourseRepositoryImpl getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public List<Course> findAll(int size, int pageNumber) {
+        int offset = size * (pageNumber - 1);
+        String sql = String.format("SELECT * FROM (SELECT c.*, ROW_NUMBER() " +
+                "OVER (ORDER BY ID DESC) AS rnum FROM COURSE c) "
+                + "WHERE rnum BETWEEN %d AND %d order by ID desc", offset + 1, offset + size);
+
+        Statement statement = StatementGenerator.generateStatement();
+        ResultSet resultSet = DataSelector.getResultSet(statement, sql);
+        List<Course> courses = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            String[] data = DataSelector.getEntityData(resultSet);
+            if (i == 0 && data == null) {
+                return courses;
+            }
+            if (data[0] == null) {
+                break;
+            }
+
+            courses.add(Course.from(data));
+        }
+
+        ConnectionContainer.close(resultSet);
+        ConnectionContainer.close(statement);
+
+        return courses;
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/model/service/CourseService.java
+++ b/src/main/java/org/chulgang/hrd/course/model/service/CourseService.java
@@ -1,0 +1,7 @@
+package org.chulgang.hrd.course.model.service;
+
+import org.chulgang.hrd.course.dto.GetCoursesResponse;
+
+public interface CourseService {
+    GetCoursesResponse getCourses(int size, int pageNumber);
+}

--- a/src/main/java/org/chulgang/hrd/course/model/service/CourseServiceImpl.java
+++ b/src/main/java/org/chulgang/hrd/course/model/service/CourseServiceImpl.java
@@ -1,0 +1,25 @@
+package org.chulgang.hrd.course.model.service;
+
+import org.chulgang.hrd.course.dto.GetCoursesResponse;
+import org.chulgang.hrd.course.model.repository.CourseRepository;
+import org.chulgang.hrd.course.model.repository.CourseRepositoryImpl;
+import org.chulgang.hrd.util.DbConnection;
+
+public class CourseServiceImpl implements CourseService {
+    private static final CourseServiceImpl INSTANCE = new CourseServiceImpl(CourseRepositoryImpl.getInstance());
+    private final CourseRepository courseRepository;
+
+    public CourseServiceImpl(CourseRepository courseRepository) {
+        this.courseRepository = courseRepository;
+    }
+
+    public static CourseServiceImpl getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public GetCoursesResponse getCourses(int size, int pageNumber) {
+        DbConnection.initialize();
+        return GetCoursesResponse.from(courseRepository.findAll(size, pageNumber));
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/util/RequestConstant.java
+++ b/src/main/java/org/chulgang/hrd/course/util/RequestConstant.java
@@ -1,0 +1,21 @@
+package org.chulgang.hrd.course.util;
+
+public class RequestConstant {
+    public static final String COURSE_DOMAIN_NAME = "course";
+    public static final String COURSE_SERVICE_ATTRIBUTE_NAME = "courseService";
+
+    public static final String GET_COURSES_FIRST_REQUEST_URL = "/elearn/course/courses.do";
+    public static final String GET_COURSES_SECOND_REQUEST_URL = "/elearn/courses.do";
+    public static final String COURSES_ATTRIBUTE_NAME = "courses";
+    public static final String SEARCH_WORD_PARAMETER_NAME = "searchWord";
+    public static final String SIZE_PARAMETER_NAME = "size";
+    public static final String PAGE_NUMBER_PARAMETER_NAME = "pageNumber";
+    public static final String COURSES_VIEW = "courses-grid.jsp";
+
+    public static final String GET_COURSE_FIRST_REQUEST_URL = "/elearn/course/course-details.do";
+    public static final String GET_COURSE_SECOND_REQUEST_URL = "/elearn/course-details.do";
+    public static final String ID_PARAMETER_NAME = "id";
+    public static final String COURSE_DETAIL_VIEW = "course-details.jsp";
+
+    public static final String REGISTER_COURSE_REQUEST_URL = "/elearn/course/registration.do";
+}

--- a/src/main/java/org/chulgang/hrd/util/AppContextListener.java
+++ b/src/main/java/org/chulgang/hrd/util/AppContextListener.java
@@ -1,0 +1,18 @@
+package org.chulgang.hrd.util;
+
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+import org.chulgang.hrd.course.model.service.CourseService;
+import org.chulgang.hrd.course.model.service.CourseServiceImpl;
+
+import static org.chulgang.hrd.course.util.RequestConstant.COURSE_SERVICE_ATTRIBUTE_NAME;
+
+@WebListener
+public class AppContextListener implements ServletContextListener {
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        CourseService courseService = CourseServiceImpl.getInstance();
+        sce.getServletContext().setAttribute(COURSE_SERVICE_ATTRIBUTE_NAME, courseService);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/util/ConnectionContainer.java
+++ b/src/main/java/org/chulgang/hrd/util/ConnectionContainer.java
@@ -1,0 +1,35 @@
+package org.chulgang.hrd.util;
+
+import org.chulgang.hrd.exception.ClosingResultSetFailedException;
+import org.chulgang.hrd.exception.ClosingStatementFailedException;
+import org.chulgang.hrd.exception.GlobalExceptionHandler;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.chulgang.hrd.exception.ExceptionMessage.CLOSING_RESULTSET_FAILED_EXCEPTION_MESSAGE;
+import static org.chulgang.hrd.exception.ExceptionMessage.CLOSING_STATEMENT_FAILED_EXCEPTION_MESSAGE;
+
+public class ConnectionContainer {
+    public static void close(ResultSet resultSet) {
+        try {
+            resultSet.close();
+        } catch (SQLException se) {
+            GlobalExceptionHandler.throwCheckedException(
+                    new ClosingResultSetFailedException(CLOSING_RESULTSET_FAILED_EXCEPTION_MESSAGE)
+            );
+        }
+    }
+
+
+    public static void close(Statement statement) {
+        try {
+            statement.close();
+        } catch (SQLException se) {
+            GlobalExceptionHandler.throwCheckedException(
+                    new ClosingStatementFailedException(CLOSING_STATEMENT_FAILED_EXCEPTION_MESSAGE)
+            );
+        }
+    }
+}

--- a/src/main/java/org/chulgang/hrd/util/DataSelector.java
+++ b/src/main/java/org/chulgang/hrd/util/DataSelector.java
@@ -1,0 +1,36 @@
+package org.chulgang.hrd.util;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class DataSelector {
+    public static ResultSet getResultSet(Statement statement, String sql) {
+        try {
+            return statement.executeQuery(sql);
+        } catch (SQLException se) {
+            se.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public static String[] getEntityData(ResultSet resultSet) {
+        try {
+            int columnCount = resultSet.getMetaData().getColumnCount();
+            String[] data = new String[columnCount];
+
+            if (resultSet.next()) {
+                for (int i = 0; i < columnCount; i++) {
+                    data[i] = resultSet.getString(i + 1);
+                }
+
+                return data;
+            }
+        } catch (SQLException se) {
+            se.printStackTrace();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/chulgang/hrd/util/FormatValidator.java
+++ b/src/main/java/org/chulgang/hrd/util/FormatValidator.java
@@ -1,0 +1,7 @@
+package org.chulgang.hrd.util;
+
+public class FormatValidator {
+    public static boolean isNoValue(String target) {
+        return target == null || target.isBlank();
+    }
+}

--- a/src/main/java/org/chulgang/hrd/util/StatementGenerator.java
+++ b/src/main/java/org/chulgang/hrd/util/StatementGenerator.java
@@ -1,0 +1,25 @@
+package org.chulgang.hrd.util;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class StatementGenerator {
+    public static Statement generateStatement() {
+        try {
+            return DbConnection.getConnection().createStatement();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static PreparedStatement generateStatement(String sql) {
+        try {
+            return DbConnection.getConnection().prepareStatement(sql);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/chulgang/hrd/course/controller/GetCoursesControllerTest.java
+++ b/src/test/java/org/chulgang/hrd/course/controller/GetCoursesControllerTest.java
@@ -1,0 +1,96 @@
+package org.chulgang.hrd.course.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.course.dto.GetCoursesResponse;
+import org.chulgang.hrd.course.model.service.CourseService;
+import org.chulgang.hrd.course.model.testutil.CourseTestObjectFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.chulgang.hrd.course.model.testutil.CourseTestConstant.*;
+import static org.chulgang.hrd.course.util.RequestConstant.*;
+import static org.mockito.Mockito.*;
+
+public class GetCoursesControllerTest {
+    private CourseService courseService;
+    private GetCoursesController getCoursesController;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private RequestDispatcher requestDispatcher;
+    private ServletConfig servletConfig;
+    private ServletContext servletContext;
+
+    @BeforeEach
+    void setUp() throws ServletException {
+        courseService = mock(CourseService.class);
+        getCoursesController = new GetCoursesController();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        requestDispatcher = mock(RequestDispatcher.class);
+        servletConfig = mock(ServletConfig.class);
+        servletContext = mock(ServletContext.class);
+
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+        when(servletContext.getAttribute(COURSE_SERVICE_ATTRIBUTE_NAME)).thenReturn(courseService);
+
+        getCoursesController.init(servletConfig);
+    }
+
+    @DisplayName("전체 강좌 목록 조회 요청을 처리할 수 있다.")
+    @Test
+    void doGetAllCourses() throws ServletException, IOException {
+        // Given
+        when(request.getRequestURI()).thenReturn(GET_COURSES_SECOND_REQUEST_URL);
+        when(request.getParameter(SIZE_PARAMETER_NAME)).thenReturn(String.valueOf(SIZE1));
+        when(request.getParameter(PAGE_NUMBER_PARAMETER_NAME)).thenReturn(String.valueOf(PAGE_NUMBER));
+        when(request.getParameter(SEARCH_WORD_PARAMETER_NAME)).thenReturn(null);
+        when(request.getRequestDispatcher(COURSES_VIEW)).thenReturn(requestDispatcher);
+
+        Course course1 = CourseTestObjectFactory.createCourse(
+                COURSE_ID1, SUBJECT_ID1, TEACHER_ID1, TIME_PERIOD_ID1,
+                NAME1, DESCRIPTION1, PRICE1, START_DATE1, LAST_DATE1
+        );
+        Course course2 = CourseTestObjectFactory.createCourse(
+                COURSE_ID2, SUBJECT_ID2, TEACHER_ID2, TIME_PERIOD_ID2,
+                NAME2, DESCRIPTION2, PRICE2, START_DATE2, LAST_DATE2
+        );
+        GetCoursesResponse getCoursesResponse = GetCoursesResponse.from(List.of(course1, course2));
+
+        when(courseService.getCourses(SIZE1, PAGE_NUMBER)).thenReturn(getCoursesResponse);
+
+        // When
+        getCoursesController.doGet(request, response);
+
+        // Then
+        ArgumentCaptor<String> attributeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<GetCoursesResponse> valueCaptor = ArgumentCaptor.forClass(GetCoursesResponse.class);
+        verify(request).setAttribute(attributeCaptor.capture(), valueCaptor.capture());
+        assertThat(attributeCaptor.getValue()).isEqualTo("courses");
+        verify(requestDispatcher).forward(request, response);
+    }
+
+    @Test
+    @DisplayName("상위 경로의 요청으로 리다이렉트할 수 있다.")
+    void doGetWithRedirect() throws ServletException, IOException {
+        // Given
+        when(request.getRequestURI()).thenReturn("/elearn/course/courses.do");
+
+        // When
+        getCoursesController.doGet(request, response);
+
+        // Then
+        verify(response).sendRedirect("/elearn/courses.do");
+    }
+}

--- a/src/test/java/org/chulgang/hrd/course/domain/CourseTest.java
+++ b/src/test/java/org/chulgang/hrd/course/domain/CourseTest.java
@@ -1,0 +1,101 @@
+package org.chulgang.hrd.course.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CourseTest {
+    private static final String COURSE_DATA_PATH
+            = "org.hrd.hrd.course.model.testutil.CourseTestDataProvider#provideCourseData";
+
+    @DisplayName("올바른 값을 전송하면 강좌 인스턴스를 생성할 수 있다.")
+    @ParameterizedTest
+    @MethodSource(COURSE_DATA_PATH)
+    void from(Long id, Long subjectId, Long teacherId, Long timePeriodId, String name, String description,
+              int price, LocalDate startDate, LocalDate lastDate, float averageScore, int remainedSeat) {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String[] data = {
+                String.valueOf(id), String.valueOf(subjectId), String.valueOf(teacherId),
+                String.valueOf(timePeriodId), name, description, String.valueOf(price), String.valueOf(startDate),
+                String.valueOf(lastDate), String.valueOf(averageScore), String.valueOf(remainedSeat),
+                String.valueOf(now), String.valueOf(now)
+        };
+
+        // when
+        Course course = Course.from(data);
+
+        // then
+        assertThat(course.getId()).isEqualTo(id);
+        assertThat(course.getSubjectId()).isEqualTo(subjectId);
+        assertThat(course.getTeacherId()).isEqualTo(teacherId);
+        assertThat(course.getTimePeriodId()).isEqualTo(timePeriodId);
+        assertThat(course.getName()).isEqualTo(name);
+        assertThat(course.getDescription()).isEqualTo(description);
+        assertThat(course.getPrice()).isEqualTo(price);
+        assertThat(course.getStartDate()).isEqualTo(startDate);
+        assertThat(course.getLastDate()).isEqualTo(lastDate);
+        assertThat(course.getAverageScore()).isEqualTo(averageScore);
+        assertThat(course.getRemainedSeat()).isEqualTo(remainedSeat);
+        assertThat(course.getCreatedAt()).isEqualTo(now);
+        assertThat(course.getModifiedAt()).isEqualTo(now);
+    }
+
+    @DisplayName("동일한 내부 값들을 전송하면 동등한 강좌 인스턴스를 생성한다.")
+    @ParameterizedTest
+    @MethodSource(COURSE_DATA_PATH)
+    void fromSameValue(Long id, Long subjectId, Long teacherId, Long timePeriodId, String name, String description,
+                       int price, LocalDate startDate, LocalDate lastDate, float averageScore, int remainedSeat) {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String[] data = {
+                String.valueOf(id), String.valueOf(subjectId), String.valueOf(teacherId),
+                String.valueOf(timePeriodId), name, description, String.valueOf(price), String.valueOf(startDate),
+                String.valueOf(lastDate), String.valueOf(averageScore), String.valueOf(remainedSeat),
+                String.valueOf(now), String.valueOf(now)
+        };
+
+        // when
+        Course course1 = Course.from(data);
+        Course course2 = Course.from(data);
+
+        // then
+        assertThat(course1).isEqualTo(course2);
+        assertThat(course1.hashCode()).isEqualTo(course2.hashCode());
+    }
+
+    @DisplayName("다른 내부 값들을 전송하면 동등하지 않은 Course 인스턴스를 생성한다.")
+    @ParameterizedTest
+    @MethodSource(COURSE_DATA_PATH)
+    void fromDifferentValue(Long id, Long subjectId, Long teacherId, Long timePeriodId, String name, String description,
+                            int price, LocalDate startDate, LocalDate lastDate, float averageScore, int remainedSeat) {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String[] data1 = {
+                String.valueOf(id), String.valueOf(subjectId), String.valueOf(teacherId),
+                String.valueOf(timePeriodId), name, description, String.valueOf(price), String.valueOf(startDate),
+                String.valueOf(lastDate), String.valueOf(averageScore), String.valueOf(remainedSeat),
+                String.valueOf(now), String.valueOf(now.plusNanos(1))
+        };
+
+        String[] data2 = {
+                String.valueOf(id), String.valueOf(subjectId), String.valueOf(teacherId),
+                String.valueOf(timePeriodId), name, description, String.valueOf(price), String.valueOf(startDate),
+                String.valueOf(lastDate), String.valueOf(averageScore), String.valueOf(remainedSeat),
+                String.valueOf(now), String.valueOf(now)
+        };
+
+        // when
+        Course course1 = Course.from(data1);
+        Course course2 = Course.from(data2);
+
+        // then
+        assertThat(course1).isNotEqualTo(course2);
+        assertThat(course1.hashCode()).isNotEqualTo(course2.hashCode());
+    }
+}

--- a/src/test/java/org/chulgang/hrd/course/model/repository/CourseRepositoryTest.java
+++ b/src/test/java/org/chulgang/hrd/course/model/repository/CourseRepositoryTest.java
@@ -1,0 +1,153 @@
+package org.chulgang.hrd.course.model.repository;
+
+import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.course.model.testutil.CourseTestConstant;
+import org.chulgang.hrd.course.model.testutil.CourseTestObjectFactory;
+import org.chulgang.hrd.util.ConnectionContainer;
+import org.chulgang.hrd.util.DbConnection;
+import org.chulgang.hrd.util.StatementGenerator;
+import org.junit.jupiter.api.*;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.chulgang.hrd.util.ConfigConstant.DB_PROPERTY_KEY;
+import static org.chulgang.hrd.util.ConfigConstant.TEST_DB_PROPERTY;
+
+class CourseRepositoryTest {
+    private CourseRepository courseRepository = CourseRepositoryImpl.getInstance();
+
+
+    @BeforeAll
+    static void setUpBeforeAll() {
+        System.setProperty(DB_PROPERTY_KEY, TEST_DB_PROPERTY);
+    }
+
+    @BeforeEach
+    void setUp() {
+        DbConnection.initialize();
+        createCourseTable();
+    }
+
+    @AfterEach
+    void tearDown() {
+        dropCourseTable();
+    }
+
+    private static void createCourseTable() {
+        String sql = "CREATE TABLE COURSE (" +
+                "ID NUMBER(19,0) NOT NULL, " +
+                "SUBJECT_ID NUMBER(19,0) NOT NULL, " +
+                "TEACHER_ID NUMBER(19,0) NOT NULL, " +
+                "TIME_PERIOD_ID NUMBER(19,0) NOT NULL, " +
+                "NAME VARCHAR2(255) NOT NULL, " +
+                "DESCRIPTION VARCHAR(4000) NULL, " +
+                "PRICE NUMBER(10,0) NOT NULL, " +
+                "START_DATE DATE NOT NULL, " +
+                "LAST_DATE DATE NOT NULL, " +
+                "AVERAGE_SCORE NUMBER(1,1) NULL DEFAULT 0.0, " +
+                "REMAINED_SEAT NUMBER(10,0) NOT NULL, " +
+                "CREATED_AT DATE NOT NULL, " +
+                "MODIFIED_AT DATE NULL" +
+                ");";
+
+        Statement statement = StatementGenerator.generateStatement();
+
+        try {
+            statement.execute(sql);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        ConnectionContainer.close(statement);
+    }
+
+    private void dropCourseTable() {
+        String sql = "DROP TABLE COURSE;";
+        Statement statement = StatementGenerator.generateStatement();
+
+        try {
+            statement.execute(sql);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        ConnectionContainer.close(statement);
+    }
+
+    @DisplayName("Singleton instance를 불러 올 수 있다.")
+    @Test
+    void getInstance() {
+        // given, when
+        CourseRepository courseRepository = CourseRepositoryImpl.getInstance();
+
+        // then
+        assertThat(courseRepository).isInstanceOf(CourseRepository.class);
+    }
+
+    @DisplayName("원하는 페이지 크기와 페이지 번호에 해당하는 강좌 목록을 내림차순으로 조회할 수 있다.")
+    @Test
+    void findAll() {
+        // given
+        Course course1 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID1, CourseTestConstant.SUBJECT_ID1, CourseTestConstant.TEACHER_ID1, CourseTestConstant.TIME_PERIOD_ID1,
+                CourseTestConstant.NAME1, CourseTestConstant.DESCRIPTION1, CourseTestConstant.PRICE1, CourseTestConstant.START_DATE1, CourseTestConstant.LAST_DATE1
+        );
+        Course course2 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID2, CourseTestConstant.SUBJECT_ID2, CourseTestConstant.TEACHER_ID2, CourseTestConstant.TIME_PERIOD_ID2,
+                CourseTestConstant.NAME2, CourseTestConstant.DESCRIPTION2, CourseTestConstant.PRICE2, CourseTestConstant.START_DATE2, CourseTestConstant.LAST_DATE2
+        );
+        Course course3 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID3, CourseTestConstant.SUBJECT_ID3, CourseTestConstant.TEACHER_ID3, CourseTestConstant.TIME_PERIOD_ID3,
+                CourseTestConstant.NAME3, CourseTestConstant.DESCRIPTION3, CourseTestConstant.PRICE3, CourseTestConstant.START_DATE3, CourseTestConstant.LAST_DATE3
+        );
+
+        courseRepository.save(course1);
+        courseRepository.save(course2);
+        courseRepository.save(course3);
+
+        // when
+        List<Course> courses1 = courseRepository.findAll(CourseTestConstant.SIZE1, CourseTestConstant.PAGE_NUMBER);
+        List<Course> courses2 = courseRepository.findAll(CourseTestConstant.SIZE2, CourseTestConstant.PAGE_NUMBER);
+
+        // then
+        assertThat(courses1).hasSize(2)
+                .extracting(
+                        "id", "subjectId", "teacherId", "timePeriodId", "name",
+                        "description", "price", "startDate", "lastDate"
+                )
+                .containsExactly(
+                        tuple(
+                                CourseTestConstant.COURSE_ID3, CourseTestConstant.SUBJECT_ID3, CourseTestConstant.TEACHER_ID3, CourseTestConstant.TIME_PERIOD_ID3,
+                                CourseTestConstant.NAME3, CourseTestConstant.DESCRIPTION3, CourseTestConstant.PRICE3, CourseTestConstant.START_DATE3, CourseTestConstant.LAST_DATE3
+                        ),
+                        tuple(
+                                CourseTestConstant.COURSE_ID2, CourseTestConstant.SUBJECT_ID2, CourseTestConstant.TEACHER_ID2, CourseTestConstant.TIME_PERIOD_ID2,
+                                CourseTestConstant.NAME2, CourseTestConstant.DESCRIPTION2, CourseTestConstant.PRICE2, CourseTestConstant.START_DATE2, CourseTestConstant.LAST_DATE2
+                        )
+                );
+
+        assertThat(courses2).hasSize(3)
+                .extracting(
+                        "id", "subjectId", "teacherId", "timePeriodId", "name",
+                        "description", "price", "startDate", "lastDate"
+                )
+                .containsExactly(
+                        tuple(
+                                CourseTestConstant.COURSE_ID3, CourseTestConstant.SUBJECT_ID3, CourseTestConstant.TEACHER_ID3, CourseTestConstant.TIME_PERIOD_ID3,
+                                CourseTestConstant.NAME3, CourseTestConstant.DESCRIPTION3, CourseTestConstant.PRICE3, CourseTestConstant.START_DATE3, CourseTestConstant.LAST_DATE3
+                        ),
+                        tuple(
+                                CourseTestConstant.COURSE_ID2, CourseTestConstant.SUBJECT_ID2, CourseTestConstant.TEACHER_ID2, CourseTestConstant.TIME_PERIOD_ID2,
+                                CourseTestConstant.NAME2, CourseTestConstant.DESCRIPTION2, CourseTestConstant.PRICE2, CourseTestConstant.START_DATE2, CourseTestConstant.LAST_DATE2
+                        ),
+                        tuple(
+                                CourseTestConstant.COURSE_ID1, CourseTestConstant.SUBJECT_ID1, CourseTestConstant.TEACHER_ID1, CourseTestConstant.TIME_PERIOD_ID1,
+                                CourseTestConstant.NAME1, CourseTestConstant.DESCRIPTION1, CourseTestConstant.PRICE1, CourseTestConstant.START_DATE1, CourseTestConstant.LAST_DATE1
+                        )
+                );
+    }
+}

--- a/src/test/java/org/chulgang/hrd/course/model/testutil/CourseTestConstant.java
+++ b/src/test/java/org/chulgang/hrd/course/model/testutil/CourseTestConstant.java
@@ -1,0 +1,64 @@
+package org.chulgang.hrd.course.model.testutil;
+
+import org.chulgang.hrd.util.FormatConverter;
+
+import java.time.LocalDate;
+
+public class CourseTestConstant {
+    public static final Long COURSE_ID1 = 1L;
+    public static final Long COURSE_ID2 = 2L;
+    public static final Long COURSE_ID3 = 3L;
+
+    public static final Long SUBJECT_ID1 = 1L;
+    public static final Long SUBJECT_ID2 = 2L;
+    public static final Long SUBJECT_ID3 = 3L;
+
+    public static final Long TEACHER_ID1 = 1L;
+    public static final Long TEACHER_ID2 = 2L;
+    public static final Long TEACHER_ID3 = 3L;
+
+    public static final Long TIME_PERIOD_ID1 = 1L;
+    public static final Long TIME_PERIOD_ID2 = 2L;
+    public static final Long TIME_PERIOD_ID3 = 3L;
+
+    public static final String NAME1 = "테스트 강의1";
+    public static final String NAME2 = "테스트 강의2";
+    public static final String NAME3 = "테스트 강의3";
+
+    public static final String DESCRIPTION1 = "테스트 강의1 설명";
+    public static final String DESCRIPTION2 = "테스트 강의2 설명";
+    public static final String DESCRIPTION3 = "테스트 강의3 설명";
+
+    public static final int PRICE1 = 10_000;
+    public static final int PRICE2 = 20_000;
+    public static final int PRICE3 = 30_000;
+
+    public static final LocalDate START_DATE1 = LocalDate.of(2024, 1, 1);
+    public static final LocalDate START_DATE2 = LocalDate.of(2024, 1, 2);
+    public static final LocalDate START_DATE3 = LocalDate.of(2024, 1, 3);
+
+    public static final LocalDate LAST_DATE1 = LocalDate.of(2024, 2, 1);
+    public static final LocalDate LAST_DATE2 = LocalDate.of(2024, 2, 2);
+    public static final LocalDate LAST_DATE3 = LocalDate.of(2024, 2, 3);
+
+    public static final String PARSED_START_DATE1 = FormatConverter.parseToString(START_DATE1);
+    public static final String PARSED_START_DATE2 = FormatConverter.parseToString(START_DATE2);
+    public static final String PARSED_START_DATE3 = FormatConverter.parseToString(START_DATE3);
+
+    public static final String PARSED_LAST_DATE1 = FormatConverter.parseToString(LAST_DATE1);
+    public static final String PARSED_LAST_DATE2 = FormatConverter.parseToString(LAST_DATE2);
+    public static final String PARSED_LAST_DATE3 = FormatConverter.parseToString(LAST_DATE3);
+
+    public static final float AVERAGE_SCORE1 = 1.5f;
+    public static final float AVERAGE_SCORE2 = 2.7f;
+    public static final float AVERAGE_SCORE3 = 3.9f;
+
+    public static final int REMAINED_SEAT1 = 10;
+    public static final int REMAINED_SEAT2 = 20;
+    public static final int REMAINED_SEAT3 = 30;
+
+    public static final int SIZE1 = 2;
+    public static final int SIZE2 = 3;
+
+    public static final int PAGE_NUMBER = 1;
+}

--- a/src/test/java/org/chulgang/hrd/course/model/testutil/CourseTestDataProvider.java
+++ b/src/test/java/org/chulgang/hrd/course/model/testutil/CourseTestDataProvider.java
@@ -1,0 +1,24 @@
+package org.chulgang.hrd.course.model.testutil;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.stream.Stream;
+
+public class CourseTestDataProvider {
+    public static Stream<Arguments> provideCourseData() {
+        return Stream.of(
+                Arguments.of(
+                        CourseTestConstant.COURSE_ID1, CourseTestConstant.SUBJECT_ID1, CourseTestConstant.TEACHER_ID1, CourseTestConstant.TIME_PERIOD_ID1, CourseTestConstant.NAME1,
+                        CourseTestConstant.DESCRIPTION1, CourseTestConstant.PRICE1, CourseTestConstant.START_DATE1, CourseTestConstant.LAST_DATE1, CourseTestConstant.AVERAGE_SCORE1, CourseTestConstant.REMAINED_SEAT1
+                ),
+                Arguments.of(
+                        CourseTestConstant.COURSE_ID2, CourseTestConstant.SUBJECT_ID2, CourseTestConstant.TEACHER_ID2, CourseTestConstant.TIME_PERIOD_ID2, CourseTestConstant.NAME2,
+                        CourseTestConstant.DESCRIPTION2, CourseTestConstant.PRICE2, CourseTestConstant.START_DATE2, CourseTestConstant.LAST_DATE2, CourseTestConstant.AVERAGE_SCORE2, CourseTestConstant.REMAINED_SEAT2
+                ),
+                Arguments.of(
+                        CourseTestConstant.COURSE_ID3, CourseTestConstant.SUBJECT_ID3, CourseTestConstant.TEACHER_ID3, CourseTestConstant.TIME_PERIOD_ID3, CourseTestConstant.NAME3,
+                        CourseTestConstant.DESCRIPTION3, CourseTestConstant.PRICE3, CourseTestConstant.START_DATE3, CourseTestConstant.LAST_DATE3, CourseTestConstant.AVERAGE_SCORE3, CourseTestConstant.REMAINED_SEAT3
+                )
+        );
+    }
+}

--- a/src/test/java/org/chulgang/hrd/course/model/testutil/CourseTestObjectFactory.java
+++ b/src/test/java/org/chulgang/hrd/course/model/testutil/CourseTestObjectFactory.java
@@ -1,0 +1,44 @@
+package org.chulgang.hrd.course.model.testutil;
+
+import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.course.dto.CreateCourseRequest;
+import org.chulgang.hrd.course.dto.GetCourseResponse;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class CourseTestObjectFactory extends Course {
+    public static Course createCourse(
+            Long id, Long subjectId, Long teacherId, Long timePeriodId, String name,
+            String description, int price, LocalDate startDate, LocalDate lastDate
+    ) {
+        return Course.of(id, subjectId, teacherId, timePeriodId, name, description, price, startDate, lastDate);
+    }
+
+    public static Course createCourse(
+            Long id, String name, String description, int price, LocalDate startDate, LocalDate lastDate,
+            float averageScore, int remainedSeat, LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        return Course.of(
+                id, name, description, price, startDate, lastDate, averageScore, remainedSeat, createdAt, modifiedAt
+        );
+    }
+
+    public static CreateCourseRequest createCourseRequest(
+            Long subjectId, Long teacherId, Long timePeriodId, String name,
+            String description, int price, LocalDate startDate, LocalDate lastDate
+    ) {
+        return CreateCourseRequest.of(
+                subjectId, teacherId, timePeriodId, name, description, price, startDate, lastDate
+        );
+    }
+
+    public static GetCourseResponse createCourseResponse(
+            Long id, String name, String description, int price, LocalDate startDate, LocalDate lastDate,
+            float averageScore, int remainedSeat, LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        return GetCourseResponse.of(
+                id, name, description, price, startDate, lastDate, averageScore, remainedSeat, createdAt, modifiedAt
+        );
+    }
+}


### PR DESCRIPTION
## resolve #15

## 추가사항

### 프로덕션 코드

#### 기능
- 강좌 목록 조회 요청
- 강좌 목록 조회 비즈니스 로직
- 강좌 목록 객체 반환
- 서블릿 포워딩

#### 유틸리티 클래스
- RequestConstant
- FormatValidator
- AppContextListener
- ConnectionContainer
- DataSelector
- StatementGenerator
- CourseIdNotFoundException
- ExceptionMessage

### 테스트 코드

#### 기능
- 강좌 목록 조회 요청, 서블릿 포워딩
- 강좌 목록 조회 비즈니스 로직
- 강좌 엔티티
    - 생성
    - 인스턴스 간 동등성 테스트
- 강좌 목록 객체 반환

#### 유틸리티 클래스
- CourseTestConstant
- CourseTestDataProvider
- CourseTestObjectFactory