### PR TITLE
[#29] 강좌 조회 기능 추가

### DIFF
--- a/src/main/java/org/chulgang/hrd/course/controller/GetCourseController.java
+++ b/src/main/java/org/chulgang/hrd/course/controller/GetCourseController.java
@@ -1,0 +1,61 @@
+package org.chulgang.hrd.course.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.chulgang.hrd.aop.LoggingAspect;
+import org.chulgang.hrd.course.model.service.CourseService;
+import org.chulgang.hrd.exception.ArgumentNoValueException;
+import org.chulgang.hrd.exception.GlobalExceptionHandler;
+import org.chulgang.hrd.util.FormatConverter;
+import org.chulgang.hrd.util.FormatValidator;
+
+import java.io.IOException;
+
+import static org.chulgang.hrd.course.util.RequestConstant.*;
+import static org.chulgang.hrd.exception.ExceptionMessage.ARGUMENT_NO_VALUE_EXCEPTION_MESSAGE;
+
+@WebServlet(urlPatterns = {GET_COURSE_FIRST_REQUEST_URL, GET_COURSE_SECOND_REQUEST_URL})
+public class GetCourseController extends HttpServlet {
+    private CourseService courseService;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+
+        courseService = LoggingAspect.createProxy(CourseService.class,
+                (CourseService) config.getServletContext().getAttribute(COURSE_SERVICE_ATTRIBUTE_NAME));
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // TODO: 이미지 추가
+        // TODO: 리뷰 추가
+        if (request.getRequestURI().contains(String.format("%s/", COURSE_DOMAIN_NAME))) {
+            response.sendRedirect(
+                    String.format(
+                            "%s?%s=%s",
+                            GET_COURSE_SECOND_REQUEST_URL, ID_PARAMETER_NAME, request.getParameter(ID_PARAMETER_NAME)
+                    )
+            );
+            return;
+        }
+
+        String id = request.getParameter(ID_PARAMETER_NAME);
+        if (FormatValidator.isNoValue(id)) {
+            GlobalExceptionHandler.throwRuntimeException(
+                    new ArgumentNoValueException(ARGUMENT_NO_VALUE_EXCEPTION_MESSAGE)
+            );
+            return;
+        }
+        Long parsedId = FormatConverter.parseToLong(id);
+
+        request.setAttribute(COURSE_DOMAIN_NAME, courseService.getCourse(parsedId));
+        RequestDispatcher requestDispatcher = request.getRequestDispatcher(COURSE_DETAIL_VIEW);
+        requestDispatcher.forward(request, response);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/dto/GetCourseResponse.java
+++ b/src/main/java/org/chulgang/hrd/course/dto/GetCourseResponse.java
@@ -1,0 +1,124 @@
+package org.chulgang.hrd.course.dto;
+
+import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.util.FormatConverter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class GetCourseResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private int price;
+    private String startDate;
+    private String lastDate;
+    private float averageScore;
+    private int remainedSeat;
+    private String createdAt;
+    private String modifiedAt;
+
+    private GetCourseResponse(
+            Long id,
+            String name,
+            String description,
+            int price,
+            String startDate,
+            String lastDate,
+            float averageScore,
+            int remainedSeat,
+            String createdAt,
+            String modifiedAt
+    ) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.startDate = startDate;
+        this.lastDate = lastDate;
+        this.averageScore = averageScore;
+        this.remainedSeat = remainedSeat;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static GetCourseResponse from(Course course) {
+        String createdAt = null;
+        if (course.getCreatedAt() != null) {
+            createdAt = FormatConverter.parseToString(course.getCreatedAt());
+        }
+
+        String modifiedAt = null;
+        if (course.getModifiedAt() != null) {
+            modifiedAt = FormatConverter.parseToString(course.getModifiedAt());
+        }
+
+        return new GetCourseResponse(
+                course.getId(),
+                course.getName(),
+                course.getDescription(),
+                course.getPrice(),
+                FormatConverter.parseToString(course.getStartDate()),
+                FormatConverter.parseToString(course.getLastDate()),
+                course.getAverageScore(),
+                course.getRemainedSeat(),
+                createdAt,
+                modifiedAt
+        );
+    }
+
+    public static GetCourseResponse of(
+            Long id, String name, String description, int price, LocalDate startDate, LocalDate lastDate,
+            float averageScore, int remainedSeat, LocalDateTime createdAt, LocalDateTime modifiedAt
+    ) {
+        String parsedStartDate = FormatConverter.parseToString(startDate);
+        String parsedLastDate = FormatConverter.parseToString(lastDate);
+        String parsedCreatedAt = FormatConverter.parseToString(createdAt);
+        String parsedModifiedAt = FormatConverter.parseToString(modifiedAt);
+
+        return new GetCourseResponse(
+                id, name, description, price, parsedStartDate, parsedLastDate,
+                averageScore, remainedSeat, parsedCreatedAt, parsedModifiedAt
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public String getLastDate() {
+        return lastDate;
+    }
+
+    public float getAverageScore() {
+        return averageScore;
+    }
+
+    public int getRemainedSeat() {
+        return remainedSeat;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getModifiedAt() {
+        return modifiedAt;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepository.java
+++ b/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface CourseRepository {
     List<Course> findAll(int size, int pageNumber);
+
+    Course findById(Long id);
 }

--- a/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepositoryImpl.java
+++ b/src/main/java/org/chulgang/hrd/course/model/repository/CourseRepositoryImpl.java
@@ -1,6 +1,8 @@
 package org.chulgang.hrd.course.model.repository;
 
 import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.course.exception.CourseIdNotFoundException;
+import org.chulgang.hrd.exception.GlobalExceptionHandler;
 import org.chulgang.hrd.util.ConnectionContainer;
 import org.chulgang.hrd.util.DataSelector;
 import org.chulgang.hrd.util.StatementGenerator;
@@ -9,6 +11,8 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.chulgang.hrd.course.exception.ExceptionMessage.COURSE_ID_NOT_FOUND_EXCEPTION_MESSAGE;
 
 public class CourseRepositoryImpl implements CourseRepository {
     private static final CourseRepositoryImpl INSTANCE = new CourseRepositoryImpl();
@@ -44,5 +48,26 @@ public class CourseRepositoryImpl implements CourseRepository {
         ConnectionContainer.close(statement);
 
         return courses;
+    }
+
+    @Override
+    public Course findById(Long id) {
+        String sql = String.format("SELECT * FROM COURSE WHERE ID = %d", id);
+
+        Statement statement = StatementGenerator.generateStatement();
+        ResultSet resultSet = DataSelector.getResultSet(statement, sql);
+        System.out.println("--------" + resultSet + "------------");
+
+        String[] data = DataSelector.getEntityData(resultSet);
+        if (data == null) {
+            GlobalExceptionHandler.throwRuntimeException(
+                    new CourseIdNotFoundException(String.format(COURSE_ID_NOT_FOUND_EXCEPTION_MESSAGE, id))
+            );
+        }
+
+        ConnectionContainer.close(resultSet);
+        ConnectionContainer.close(statement);
+
+        return Course.from(data);
     }
 }

--- a/src/main/java/org/chulgang/hrd/course/model/service/CourseService.java
+++ b/src/main/java/org/chulgang/hrd/course/model/service/CourseService.java
@@ -1,7 +1,10 @@
 package org.chulgang.hrd.course.model.service;
 
+import org.chulgang.hrd.course.dto.GetCourseResponse;
 import org.chulgang.hrd.course.dto.GetCoursesResponse;
 
 public interface CourseService {
     GetCoursesResponse getCourses(int size, int pageNumber);
+
+    GetCourseResponse getCourse(Long id);
 }

--- a/src/main/java/org/chulgang/hrd/course/model/service/CourseServiceImpl.java
+++ b/src/main/java/org/chulgang/hrd/course/model/service/CourseServiceImpl.java
@@ -1,5 +1,6 @@
 package org.chulgang.hrd.course.model.service;
 
+import org.chulgang.hrd.course.dto.GetCourseResponse;
 import org.chulgang.hrd.course.dto.GetCoursesResponse;
 import org.chulgang.hrd.course.model.repository.CourseRepository;
 import org.chulgang.hrd.course.model.repository.CourseRepositoryImpl;
@@ -21,5 +22,11 @@ public class CourseServiceImpl implements CourseService {
     public GetCoursesResponse getCourses(int size, int pageNumber) {
         DbConnection.initialize();
         return GetCoursesResponse.from(courseRepository.findAll(size, pageNumber));
+    }
+
+    @Override
+    public GetCourseResponse getCourse(Long id) {
+        DbConnection.initialize();
+        return GetCourseResponse.from(courseRepository.findById(id));
     }
 }

--- a/src/main/java/org/chulgang/hrd/exception/ArgumentNoValueException.java
+++ b/src/main/java/org/chulgang/hrd/exception/ArgumentNoValueException.java
@@ -1,0 +1,7 @@
+package org.chulgang.hrd.exception;
+
+public class ArgumentNoValueException extends IllegalArgumentException {
+    public ArgumentNoValueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/exception/ClosingResultSetFailedException.java
+++ b/src/main/java/org/chulgang/hrd/exception/ClosingResultSetFailedException.java
@@ -1,0 +1,9 @@
+package org.chulgang.hrd.exception;
+
+import java.sql.SQLException;
+
+public class ClosingResultSetFailedException extends SQLException {
+    public ClosingResultSetFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/exception/ClosingStatementFailedException.java
+++ b/src/main/java/org/chulgang/hrd/exception/ClosingStatementFailedException.java
@@ -1,0 +1,9 @@
+package org.chulgang.hrd.exception;
+
+import java.sql.SQLException;
+
+public class ClosingStatementFailedException extends SQLException {
+    public ClosingStatementFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/chulgang/hrd/exception/EntityNotFoundException.java
+++ b/src/main/java/org/chulgang/hrd/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package org.chulgang.hrd.exception;
+
+public abstract class EntityNotFoundException extends RuntimeException {
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/org/chulgang/hrd/course/controller/GetCourseControllerTest.java
+++ b/src/test/java/org/chulgang/hrd/course/controller/GetCourseControllerTest.java
@@ -1,0 +1,85 @@
+package org.chulgang.hrd.course.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.chulgang.hrd.course.dto.GetCourseResponse;
+import org.chulgang.hrd.course.model.service.CourseService;
+import org.chulgang.hrd.course.model.testutil.CourseTestObjectFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.chulgang.hrd.course.model.testutil.CourseTestConstant.*;
+import static org.chulgang.hrd.course.util.RequestConstant.*;
+import static org.mockito.Mockito.*;
+
+public class GetCourseControllerTest {
+    CourseService courseService = mock(CourseService.class);
+    GetCourseController getCourseController = new GetCourseController();
+    private ServletConfig servletConfig;
+    private ServletContext servletContext;
+
+    @DisplayName("강좌 ID를 통해 해당 강좌 조회를 요청하고 처리할 수 있다.")
+    @Test
+    void doGet() throws ServletException, IOException {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        RequestDispatcher requestDispatcher = mock(RequestDispatcher.class);
+        servletConfig = mock(ServletConfig.class);
+        servletContext = mock(ServletContext.class);
+
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+        when(servletContext.getAttribute(COURSE_SERVICE_ATTRIBUTE_NAME)).thenReturn(courseService);
+
+        getCourseController.init(servletConfig);
+
+        when(request.getRequestURI()).thenReturn(GET_COURSE_SECOND_REQUEST_URL);
+        when(request.getParameter(ID_PARAMETER_NAME)).thenReturn("1");
+        when(request.getRequestDispatcher(COURSE_DETAIL_VIEW)).thenReturn(requestDispatcher);
+
+        GetCourseResponse getCourseResponse = CourseTestObjectFactory.createCourseResponse(
+                COURSE_ID1, NAME1, DESCRIPTION1, PRICE1, START_DATE1,
+                LAST_DATE1, AVERAGE_SCORE1, REMAINED_SEAT1, now, now
+        );
+        when(courseService.getCourse(COURSE_ID1)).thenReturn(getCourseResponse);
+
+        // When
+        getCourseController.doGet(request, response);
+
+        // Then
+        ArgumentCaptor<String> attributeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> valueCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(request).setAttribute(attributeCaptor.capture(), valueCaptor.capture());
+        assertThat(attributeCaptor.getValue()).isEqualTo("course");
+        assertThat(valueCaptor.getValue()).isEqualTo(getCourseResponse);
+
+        verify(requestDispatcher).forward(request, response);
+    }
+
+    @Test
+    @DisplayName("강좌 조회 요청 후 상위 경로의 요청으로 리다이렉트할 수 있다.")
+    void doGetWithRedirect() throws ServletException, IOException {
+        // Given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getRequestURI()).thenReturn("/elearn/course/course-details.do");
+        when(request.getParameter("id")).thenReturn("1");
+
+        // When
+        getCourseController.doGet(request, response);
+
+        // Then
+        verify(response).sendRedirect("/elearn/course-details.do?id=1");
+    }
+}

--- a/src/test/java/org/chulgang/hrd/course/model/repository/CourseRepositoryTest.java
+++ b/src/test/java/org/chulgang/hrd/course/model/repository/CourseRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.chulgang.hrd.course.model.repository;
 
 import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.course.exception.CourseIdNotFoundException;
 import org.chulgang.hrd.course.model.testutil.CourseTestConstant;
 import org.chulgang.hrd.course.model.testutil.CourseTestObjectFactory;
 import org.chulgang.hrd.util.ConnectionContainer;
@@ -12,8 +13,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.*;
+import static org.chulgang.hrd.course.exception.ExceptionMessage.COURSE_ID_NOT_FOUND_EXCEPTION_MESSAGE;
 import static org.chulgang.hrd.util.ConfigConstant.DB_PROPERTY_KEY;
 import static org.chulgang.hrd.util.ConfigConstant.TEST_DB_PROPERTY;
 
@@ -149,5 +150,59 @@ class CourseRepositoryTest {
                                 CourseTestConstant.NAME1, CourseTestConstant.DESCRIPTION1, CourseTestConstant.PRICE1, CourseTestConstant.START_DATE1, CourseTestConstant.LAST_DATE1
                         )
                 );
+    }
+
+    @DisplayName("강좌 ID를 통해 해당하는 강좌를 조회할 수 있다.")
+    @Test
+    void findById() {
+        // given
+        Course createdCourse1 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID1, CourseTestConstant.SUBJECT_ID1, CourseTestConstant.TEACHER_ID1, CourseTestConstant.TIME_PERIOD_ID1,
+                CourseTestConstant.NAME1, CourseTestConstant.DESCRIPTION1, CourseTestConstant.PRICE1, CourseTestConstant.START_DATE1, CourseTestConstant.LAST_DATE1
+        );
+
+        Course createdCourse2 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID2, CourseTestConstant.SUBJECT_ID2, CourseTestConstant.TEACHER_ID2, CourseTestConstant.TIME_PERIOD_ID2,
+                CourseTestConstant.NAME2, CourseTestConstant.DESCRIPTION2, CourseTestConstant.PRICE2, CourseTestConstant.START_DATE2, CourseTestConstant.LAST_DATE2
+        );
+
+        Course createdCourse3 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID3, CourseTestConstant.SUBJECT_ID3, CourseTestConstant.TEACHER_ID3, CourseTestConstant.TIME_PERIOD_ID3,
+                CourseTestConstant.NAME3, CourseTestConstant.DESCRIPTION3, CourseTestConstant.PRICE3, CourseTestConstant.START_DATE3, CourseTestConstant.LAST_DATE3
+        );
+
+        courseRepository.save(createdCourse1);
+        courseRepository.save(createdCourse2);
+        courseRepository.save(createdCourse3);
+
+        // when
+        Course foundCourse = courseRepository.findById(createdCourse2.getId());
+
+        // then
+        assertThat(foundCourse).isEqualTo(createdCourse2);
+    }
+
+    @DisplayName("존재하지 않는 강좌 ID를 통해 강좌를 조회하려 하면 CourseIdNotFoundException이 발생한다.")
+    @Test
+    void findByIdFromNonExistentCourse() {
+        // given
+        Course createdCourse1 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID1, CourseTestConstant.SUBJECT_ID1, CourseTestConstant.TEACHER_ID1, CourseTestConstant.TIME_PERIOD_ID1,
+                CourseTestConstant.NAME1, CourseTestConstant.DESCRIPTION1, CourseTestConstant.PRICE1, CourseTestConstant.START_DATE1, CourseTestConstant.LAST_DATE1
+        );
+
+
+        Course createdCourse2 = CourseTestObjectFactory.createCourse(
+                CourseTestConstant.COURSE_ID3, CourseTestConstant.SUBJECT_ID3, CourseTestConstant.TEACHER_ID3, CourseTestConstant.TIME_PERIOD_ID3,
+                CourseTestConstant.NAME3, CourseTestConstant.DESCRIPTION3, CourseTestConstant.PRICE3, CourseTestConstant.START_DATE3, CourseTestConstant.LAST_DATE3
+        );
+
+        courseRepository.save(createdCourse1);
+        courseRepository.save(createdCourse2);
+
+        // when, then
+        assertThatThrownBy(() -> courseRepository.findById(CourseTestConstant.COURSE_ID2))
+                .isInstanceOf(CourseIdNotFoundException.class)
+                .hasMessage(String.format(COURSE_ID_NOT_FOUND_EXCEPTION_MESSAGE, CourseTestConstant.COURSE_ID2));
     }
 }

--- a/src/test/java/org/chulgang/hrd/course/model/service/CourseServiceTest.java
+++ b/src/test/java/org/chulgang/hrd/course/model/service/CourseServiceTest.java
@@ -1,6 +1,7 @@
 package org.chulgang.hrd.course.model.service;
 
 import org.chulgang.hrd.course.domain.Course;
+import org.chulgang.hrd.course.dto.GetCourseResponse;
 import org.chulgang.hrd.course.dto.GetCoursesResponse;
 import org.chulgang.hrd.course.model.repository.CourseRepository;
 import org.chulgang.hrd.course.model.testutil.CourseTestObjectFactory;
@@ -114,5 +115,33 @@ class CourseServiceTest {
                                 AVERAGE_SCORE3, REMAINED_SEAT3, parsedNow, parsedNow
                         )
                 );
+    }
+
+    @DisplayName("강좌 ID를 통해 원하는 강좌를 조회할 수 있다.")
+    @Test
+    void getCourse() {
+        // given
+        when(courseRepository.findById(anyLong())).thenReturn(
+                CourseTestObjectFactory.createCourse(
+                        COURSE_ID1, NAME1, DESCRIPTION1, PRICE1, START_DATE1, LAST_DATE1,
+                        AVERAGE_SCORE1, REMAINED_SEAT1, now, now
+                )
+        );
+
+        // when
+        GetCourseResponse getCourseResponse = courseService.getCourse(COURSE_ID1);
+
+        // then
+        assertThat(getCourseResponse).isNotNull();
+        assertThat(getCourseResponse.getId()).isEqualTo(COURSE_ID1);
+        assertThat(getCourseResponse.getName()).isEqualTo(NAME1);
+        assertThat(getCourseResponse.getDescription()).isEqualTo(DESCRIPTION1);
+        assertThat(getCourseResponse.getPrice()).isEqualTo(PRICE1);
+        assertThat(getCourseResponse.getStartDate()).isEqualTo(PARSED_START_DATE1);
+        assertThat(getCourseResponse.getLastDate()).isEqualTo(PARSED_LAST_DATE1);
+        assertThat(getCourseResponse.getAverageScore()).isEqualTo(AVERAGE_SCORE1);
+        assertThat(getCourseResponse.getRemainedSeat()).isEqualTo(REMAINED_SEAT1);
+        assertThat(getCourseResponse.getCreatedAt()).isEqualTo(FormatConverter.parseToString(now));
+        assertThat(getCourseResponse.getModifiedAt()).isEqualTo(FormatConverter.parseToString(now));
     }
 }


### PR DESCRIPTION
## resolve #29

## 추가사항

### 프로덕션 코드

#### 기능
- 강좌 조회 요청
- 강좌 조회 비즈니스 로직
- 강좌 응답 객체 반환
- 서블릿 포워딩

#### 유틸리티 클래스
- ArgumentNoValueException
- ClosingResultSetFailedException
- ClosingStatementFailedException
- EntityNotFoundException


### 테스트 코드
- 강좌 조회 요청, 서블릿 포워딩
- 강좌 조회 비즈니스 로직
- 존재하지 않는 ID로 요청 시 예외 처리
- 강좌 응답 객체 반환